### PR TITLE
모달 사용성 개선

### DIFF
--- a/src/components/UI/Item.jsx
+++ b/src/components/UI/Item.jsx
@@ -6,12 +6,29 @@ import { useState } from "react";
 
 const Item = ({ item, setBookmarkState, isBookmarked }) => {
   const [modalState, setModalState] = useState(false);
+  const [willBookmarked, setWillBookmarked] = useState(false);
+
   const handleModalOpen = () => {
     setModalState(true);
+    setWillBookmarked(isBookmarked);
   };
   const handleModalClose = () => {
+    if (isBookmarked && !willBookmarked) {
+      const bookmark = JSON.parse(localStorage.getItem("bookmark"));
+      const existingItemIndex = bookmark.findIndex((x) => x.id === item.id);
+      bookmark.splice(existingItemIndex, 1);
+      localStorage.setItem("bookmark", JSON.stringify(bookmark));
+      setBookmarkState(JSON.parse(localStorage.getItem("bookmark")));
+    }
+    if (!isBookmarked && willBookmarked) {
+      const bookmark = JSON.parse(localStorage.getItem("bookmark")) || [];
+      bookmark.unshift(item);
+      localStorage.setItem("bookmark", JSON.stringify(bookmark));
+      setBookmarkState(JSON.parse(localStorage.getItem("bookmark")));
+    }
     setModalState(false);
   };
+
   const handleBookmark = (e, item) => {
     const bookmark = JSON.parse(localStorage.getItem("bookmark")) || [];
     const existingItemIndex = bookmark.findIndex((x) => x.id === item.id);
@@ -23,14 +40,7 @@ const Item = ({ item, setBookmarkState, isBookmarked }) => {
       bookmark.unshift(item);
     }
 
-    // localStorage.setItem("bookmark", JSON.stringify(bookmark));
-    // if (e.currentTarget === e.target && modalState) {
-    //   setBookmarkState(JSON.parse(localStorage.getItem("bookmark")));
-    // } else if (!modalState) {
-    //   setBookmarkState(JSON.parse(localStorage.getItem("bookmark")));
-    // }
     localStorage.setItem("bookmark", JSON.stringify(bookmark));
-    if (modalState) setModalState(false);
     setBookmarkState(JSON.parse(localStorage.getItem("bookmark")));
   };
 
@@ -43,6 +53,8 @@ const Item = ({ item, setBookmarkState, isBookmarked }) => {
           isBookmarked={isBookmarked}
           handleBookmark={(e) => handleBookmark(e, item)}
           title={item.title || item.brand_name}
+          willBookmarked={willBookmarked}
+          setWillBookmarked={setWillBookmarked}
         />
       )}
       <div className={styles.item}>

--- a/src/components/UI/Modal.jsx
+++ b/src/components/UI/Modal.jsx
@@ -1,7 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
 import { faX } from "@fortawesome/free-solid-svg-icons";
-
+import { useState } from "react";
 import classes from "./Modal.module.css";
 
 const Modal = ({
@@ -10,11 +10,16 @@ const Modal = ({
   isBookmarked,
   handleBookmark,
   title,
+  willBookmarked,
+  setWillBookmarked,
 }) => {
   const handleOverlayClick = (event) => {
     if (event.target === event.currentTarget) {
       handleModalClose();
     }
+  };
+  const handelModalBookmark = () => {
+    setWillBookmarked((prev) => !prev);
   };
 
   return (
@@ -30,10 +35,10 @@ const Modal = ({
         <img className={classes.img} src={imageUrl} alt="modalImg" />
         <span className={classes.title}>{title}</span>
         <FontAwesomeIcon
-          className={isBookmarked ? classes.bookcolor : classes.bookmark}
+          className={willBookmarked ? classes.bookcolor : classes.bookmark}
           size="lg"
           icon={faStar}
-          onClick={handleBookmark}
+          onClick={handelModalBookmark}
         />
       </div>
     </div>


### PR DESCRIPTION
모달 사용성 개선

- [x] 아이템의 이미지를 클릭하면 화면에 모달 띄우기
- [x] 백드롭 클릭하거나 x 버튼을 누르면 닫힘
- [x] 클릭한 이미지를 적절한 크기로 잘라서 모달에 보여줌
- [x] 모달상의 별을 통해서 북마크를 추가하거나 삭제할 수 있음
- [x] 모달상에서 별을 클릭해 북마크 삭제를 할 경우 클릭 즉시 모달이 사라지지 않고 최종적으로 모달을 닫아야만 북마크가 업데이트됨(사용성 개선) 

1차 코드리뷰 PR
무한스크롤 + 필터 기능을 구현하는 것이 어려웠습니다.

문제1. 전체 데이터를 받아와서 상태로 저장하고, 화면에 보여줄 데이터를 설정하기 위해 또다른 상태를 설정하고 있는데 이렇게 하는 것이 적절한지 모르곘습니다.

문제2. 상태 변화가 예측한 순서대로 이뤄지도록 하기 위해 useEffect여러개를 사용하고 있는데 괜찮은 것일까요?

문제3. 처음에 데이터를 가져와서 끊은 다음에 필터를 적용하려고 이미 끊어진 데이터 내에서 필터를 적용하게 돼서 다른 타입으로 넘어갔을 때 12개씩 데이터가 표시되는 것이 아니라 랜덤한 개수로 데이터가 표시됩니다.

문제4. 무한스크롤과 필터를 구현하면서 동시에 데이터를 네개씩 끊어서 div를 생성하는 코드를 만들고 싶은데 코드 적용 순서를 어떻게 해야할지 모르겠습니다. 그래서 그냥 전체 flex-wrap을 주었습니다..