### PR TITLE
무한스크롤 기능 개선

### DIFF
--- a/src/pages/BookmarkListPage.jsx
+++ b/src/pages/BookmarkListPage.jsx
@@ -2,19 +2,16 @@ import Item from "../components/UI/Item";
 import Types from "../components/Types";
 import styles from "./ProductListPage.module.css";
 import Error from "../components/UI/Error";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 function BookmarkListPage({ bookmarkState, setBookmarkState }) {
-  const [displayData, setDisplayData] = useState([]);
-  const [currentType, setCurrentType] = useState("all");
-
   const ITEMS_PER_PAGE = 12;
-  const obsRef = useRef(null); //observer Element
-  const [page, setPage] = useState(1); //현재 페이지
-  const [isLoading, setIsLoading] = useState(false); //로딩 스피너
-  const preventRef = useRef(true); //옵저버 중복 실행 방지
+  const [page, setPage] = useState(1);
+  const [currentType, setCurrentType] = useState("all");
+  const [isLoading, setIsLoading] = useState(false);
+  const obsRef = useRef(null);
 
   /* 북마크된 요소인지 확인(prop 전달용) */
   const checkIsBookmarked = (item) => {
@@ -22,17 +19,6 @@ function BookmarkListPage({ bookmarkState, setBookmarkState }) {
       return bookmarkState.some((x) => x.id === item.id);
     }
     return false;
-  };
-
-  /* 화면에 표시할 데이터를 업데이트 */
-  const updateDisplayData = (start, end) => {
-    setDisplayData(
-      bookmarkState
-        .filter((item) =>
-          currentType === "all" ? true : item.type === currentType
-        )
-        .slice(start, end)
-    );
   };
 
   /* 첫 렌더시 옵저버 생성 */
@@ -48,48 +34,22 @@ function BookmarkListPage({ bookmarkState, setBookmarkState }) {
 
   /* 옵저버 콜백함수 */
   const obsHandler = (entries) => {
-    const target = entries[0];
-    if (target.isIntersecting && preventRef.current) {
-      preventRef.current = false; //옵저버 중복 실행 방지
-      setPage((prev) => prev + 1); //페이지 값 증가
-    }
-  };
-
-  /* 북마크를 삭제하면 보여줄 데이터를 재설정 */
-  useEffect(() => {
-    updateDisplayData(0, page * ITEMS_PER_PAGE);
-  }, [bookmarkState]);
-
-  /* 타입을 변경하면 보여줄 데이터를 재설정하고 페이지 초기화 */
-  useEffect(() => {
-    updateDisplayData(0, ITEMS_PER_PAGE);
-    setPage(1);
-  }, [currentType]);
-
-  /* 페이지 변경시 보여줄 데이터를 재설정 */
-  useEffect(() => {
-    if (page !== 1 && !isLoading) getPost();
-  }, [page]);
-
-  let timer = null;
-  const getPost = () => {
     setIsLoading(true);
-    if (timer) {
-      clearTimeout(timer);
-    }
-    timer = setTimeout(() => {
-      setDisplayData((prev) => [
-        ...prev,
-        ...bookmarkState
-          .filter((item) =>
-            currentType === "all" ? true : item.type === currentType
-          )
-          .slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE),
-      ]);
-      preventRef.current = true;
+    setTimeout(() => {
+      const target = entries[0];
+      if (target.isIntersecting && !isLoading) {
+        setPage((prev) => prev + 1);
+      }
       setIsLoading(false);
     }, 500);
   };
+
+  // useMemo
+  const filteredItem = useMemo(() => {
+    if (currentType === "all") {
+      return bookmarkState;
+    } else return bookmarkState.filter((item) => item.type === currentType);
+  }, [currentType, bookmarkState]);
 
   return (
     <div className={styles.mainbox}>
@@ -104,15 +64,17 @@ function BookmarkListPage({ bookmarkState, setBookmarkState }) {
         {" "}
         <div className={styles.itemBox}>
           {bookmarkState && bookmarkState.length !== 0 ? (
-            displayData.map((item) => (
-              <Item
-                key={item.id_ + "_"}
-                item={item}
-                isBookmarked={checkIsBookmarked(item)}
-                bookmarkState={bookmarkState}
-                setBookmarkState={setBookmarkState}
-              />
-            ))
+            filteredItem
+              .slice(0, ITEMS_PER_PAGE * page)
+              .map((item) => (
+                <Item
+                  key={item.id_ + "_"}
+                  item={item}
+                  isBookmarked={checkIsBookmarked(item)}
+                  bookmarkState={bookmarkState}
+                  setBookmarkState={setBookmarkState}
+                />
+              ))
           ) : (
             <Error />
           )}
@@ -125,7 +87,9 @@ function BookmarkListPage({ bookmarkState, setBookmarkState }) {
             <div></div>
           </div>
         )}
-        <div ref={obsRef}></div>
+        {page < Math.ceil(filteredItem.length / ITEMS_PER_PAGE) && (
+          <div ref={obsRef}></div>
+        )}
       </>
     </div>
   );


### PR DESCRIPTION
무한스크롤 로직을 개선했습니다.
북마크페이지에서 마지막 페이지에서 데이터 추가 로드를 중지하도록 했습니다.
상품리스트 페이지에서 같은 기능을 도입하려 하는데 데이터 요청 코드 때문에 어디서 마지막 페이지를 계산하도록 해야 할지 몰라서 아직 구현하지 못했습니다.